### PR TITLE
Fix path to icons

### DIFF
--- a/components/appIcon.vue
+++ b/components/appIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg-icon
-    :name="`${name}/${name}`"
+    :name="name"
     class="app-icon"
   />
 </template>


### PR DESCRIPTION
Fixes exception:
```
 ERROR  [Vue warn]: Error in render: "Error: Cannot find module './search.svg'"                                                    16:46:22

found in

---> <AppIcon> at components/appIcon.vue
       <AppNavAccordion> at components/appNavAccordion.vue
         <AppMainNav> at partials/appMainNav.vue
           <AppHeader> at partials/appHeader.vue
             <Layouts/default.vue> at layouts/default.vue
               <Root>
```
based on documentation of https://www.npmjs.com/package/@nuxtjs/svg-sprite
reverts changes made in f2d970b20b64da88193292944af90ae32a18b56e (what this commit fixes???)
was missed in 485e22ab4890782905fe1a823d908e71ecfdfc16