### PR TITLE
Show additional account information

### DIFF
--- a/pages/account/_transactions/_id.vue
+++ b/pages/account/_transactions/_id.vue
@@ -5,6 +5,7 @@
       :has-crumbs="true"
       :page="{to: `/account/transactions/${$route.params.id}`, name: `${$route.params.id}`}"
     />
+    <AccountDetails :account="accountDetails" />
     <div class="filter">
       <multiselect
         v-model="value"
@@ -43,6 +44,7 @@ import PageHeader from '../../../components/PageHeader'
 import LoadMoreButton from '../../../components/loadMoreButton'
 import Multiselect from 'vue-multiselect'
 import { transformMetaTx } from '../../../store/utils'
+import AccountDetails from '../../../partials/accountDetails.vue'
 
 export default {
   name: 'AccountTransactions',
@@ -51,7 +53,8 @@ export default {
     TXListItem,
     PageHeader,
     LoadMoreButton,
-    Multiselect
+    Multiselect,
+    AccountDetails
   },
   async asyncData ({ store, params, query }) {
     let value = null
@@ -66,14 +69,16 @@ export default {
       element = element.tx.type === 'GAMetaTx' ? transformMetaTx(element) : element
       transactions.push(element)
     })
+    const accountDetails = await store.dispatch('account/getAccountDetails', params.id)
     value = value || 'All'
-    return { address: params.id, transactions, page: 2, value, loading: false }
+    return { address: params.id, transactions, page: 2, value, loading: false, accountDetails }
   },
   data () {
     return {
       account: {
         id: this.$route.params.id
       },
+      accountDetails: {},
       transactions: [],
       page: 1,
       loading: true,

--- a/partials/accountDetails.vue
+++ b/partials/accountDetails.vue
@@ -1,0 +1,85 @@
+<template>
+  <!-- <p>{{ account }}</p> -->
+  <AppPanel class="account-details">
+    <div class="account-details-id">
+      <Account
+        :value="account.id"
+        title="Address"
+        icon
+      />
+      <AppDefinition title="Account type">
+        {{ account.kind }}
+      </AppDefinition>
+      <Account
+        v-if="account['contract_id']"
+        :value="account['contract_id']"
+        title="Contract ID"
+        icon
+      />
+    </div>
+    <div class="account-details-info">
+      <AppDefinition
+        title="Balance"
+      >
+        <FormatAeUnit :value="account.balance" />
+      </AppDefinition>
+      <AppDefinition
+        v-if="account['auth_fun']"
+        title="Authentication function"
+      >
+        {{ account['auth_fun'] }}
+      </AppDefinition>
+    </div>
+  </AppPanel>
+</template>
+
+<script>
+import Account from '../components/account.vue'
+import AppDefinition from '../components/appDefinition.vue'
+import AppPanel from '../components/appPanel.vue'
+import FormatAeUnit from '../components/formatAeUnit.vue'
+export default {
+  name: 'AccountDetails',
+  components: { AppDefinition,
+    FormatAeUnit,
+    Account,
+    AppPanel },
+  props: {
+    account: { type: Object, required: true } }
+}
+</script>
+
+<style lang="scss" scoped>
+.account-details {
+  display: flex;
+  flex-direction: column;
+  padding: 0.6rem;
+
+  @media (min-width: 550px) {
+    flex-direction: row;
+  }
+  .account-details-id {
+    width: 100%;
+    @media (min-width: 550px) {
+      width: 60%;
+      justify-content: space-between;
+    }
+      @media (min-width: 1600px) {
+      width: 65%;
+    }
+  }
+  .account-details-info {
+    border-top: 2px solid #EDF3F7;
+
+    @media (min-width: 550px) {
+      width: 40%;
+      flex-direction: row;
+      border-top: none;
+      border-left: 2px solid #EDF3F7;
+    }
+    @media (min-width: 1600px) {
+      width: 35%;
+    }
+  }
+}
+</style>

--- a/store/account.js
+++ b/store/account.js
@@ -3,7 +3,7 @@ import { fetchJson } from './utils'
 export const actions = {
   getAccountDetails: async function ({ rootState: { nodeUrl }, commit }, account) {
     try {
-      const acc = await fetchJson(`${nodeUrl.slice(0, -4)}/v2/accounts/${account}`)
+      const acc = await fetchJson(`${nodeUrl.slice(0, -4)}/v3/accounts/${account}`)
       return acc
     } catch (e) {
       commit('catchError', 'Error', { root: true })


### PR DESCRIPTION
Fixes #28 

<img width=800 src=https://user-images.githubusercontent.com/47859124/131472381-44a59592-b6e3-4352-bf7e-0672811ee696.png>

<img width=800 src=https://user-images.githubusercontent.com/47859124/131472615-9f944d03-e34f-4893-a2bb-91f1a0fcccfa.png>

Though, I'm not sure about the order of the items especially about the address to be right below the breadcrumb .
