### PR TITLE
Show generation info in transaction details

### DIFF
--- a/pages/transactions/_transaction/index.vue
+++ b/pages/transactions/_transaction/index.vue
@@ -51,9 +51,11 @@ export default {
     }
     generation = store.state.generations.generations?.[txDetails.blockHeight]
     if (!generation) {
-      generation = (await store.dispatch('generations/getGenerationByRange', { start: (txDetails.blockHeight - 1), end: (txDetails.blockHeight + 1) }))[txDetails.blockHeight]
+      generation = (await store.dispatch('generations/getGenerationByRange', { start: (txDetails.blockHeight - 1), end: (txDetails.blockHeight + 1) }))
+        .find(g => g.height === txDetails.blockHeight)
     }
-    if (!store.state.height) {
+    height = store.state.height
+    if (!height) {
       height = await store.dispatch('height')
     }
     if (txDetails.tx.contractId) {


### PR DESCRIPTION
I think this also fixes #71 

Before:
<img width="800" alt="Screenshot 2021-09-03 at 16 49 33" src="https://user-images.githubusercontent.com/47859124/132015988-4fb93d63-d0a5-4789-91f8-3528cc64dd0a.png">
After:
<img width="800" alt="Screenshot 2021-09-03 at 16 49 33" src="https://user-images.githubusercontent.com/47859124/132016473-a35f1382-1289-43de-9622-b6f8b01443f1.png">
