### PR TITLE
Fix build config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,12 @@
 const pkg = require('./package')
 
 module.exports = {
+  target: 'static',
+  ssr: false,
+  generate: {
+    exclude: [/^\/.+/],
+    crawler: false
+  },
   /*
   ** Headers of the page
   */


### PR DESCRIPTION
Frontend should not build SSR as it works only in client mode (hosted in s3), also crawling and prebuilding the urls is meaningless (and also impossible as it tries to crawl all transaction urls and etc.)