### PR TITLE
Feature/tokens page style

### DIFF
--- a/pages/tokens/_token/index.vue
+++ b/pages/tokens/_token/index.vue
@@ -63,7 +63,6 @@
             >
               From
             </th>
-            <th scope="col" />
             <th
               scope="col"
               class="address-col"
@@ -100,7 +99,6 @@
                   length="responsive"
                 />
               </td>
-              <td>→</td>
               <td>
                 <FormatAddress
                   :value="transaction.tx.arguments.find(a=>a.type === 'address').value"
@@ -175,7 +173,8 @@ export default {
     const tokenInfo = allTokens.find(t => t.contractId === token)
     const tokenBalances = await store.dispatch('tokens/getTokenBalances', token)
     const { data, next } = await store.dispatch('contracts/getContractCalls', { contract: token, page: 1, limit: 25 })
-    return { token, tokenInfo, tokenBalances, transactions: data, loading: false, page: 2, nextPage: !!next }
+    const transactions = data.filter(({ tx }) => tx.function === 'transfer' || tx.function === 'mint')
+    return { token, tokenInfo, tokenBalances, transactions, loading: false, page: 2, nextPage: !!next }
   },
   data () {
     return {
@@ -241,6 +240,7 @@ export default {
   table {
     width: 100%;
     margin-top: 1em;
+    border-collapse: collapse;
 
     tr:hover {
       background-color: #fff;
@@ -249,6 +249,10 @@ export default {
     th {
       text-align: left;
       background-color: #fff;
+      font-weight: 700;
+      border-bottom: 2px solid $color-neutral-positive-2;
+      padding: .6rem 0 .6rem .5rem;
+      font-size: 16px;
 
       &.address-col {
         min-width: 120px;
@@ -257,6 +261,20 @@ export default {
         min-width: 90px;
       }
 
+      &:not(:first-child) {
+        border-left: 2px solid $color-neutral-positive-2;
+      }
+
+    }
+    tr {
+      border-bottom: 1px solid $color-neutral-positive-2;
+    }
+    td {
+      @extend %face-mono-s;
+      font-size: 14px;
+      &:not(:first-child) {
+        border-left: 1px solid $color-neutral-positive-2;
+      }
     }
     .function {
       white-space: nowrap;

--- a/partials/accountDetails.vue
+++ b/partials/accountDetails.vue
@@ -33,15 +33,27 @@
         v-if="tokensBalance.length > 0"
         title="tokens"
       >
-        <p
-          v-for="(token, index) in tokensBalance"
-          :key="index"
-          class="token"
-        >
-          <nuxt-link :to="`/tokens/${token.contractId}`">
-            {{ token.amount | formatToken(token.decimals, token.symbol) }}
-          </nuxt-link>
-        </p>
+        <div class="show-zero">
+          <button
+            class="show-btn"
+            :class="{active: !showZeros}"
+            @click="showZeros = !showZeros"
+          >
+            <AppIcon name="check" />
+          </button>
+          Hide empty balances
+        </div>
+        <div class="tokens-balances">
+          <p
+            v-for="(token, index) in showZeros? tokensBalance : tokensWithBalance"
+            :key="index"
+            class="token"
+          >
+            <nuxt-link :to="`/tokens/${token.contractId}`">
+              {{ token.amount | formatToken(token.decimals, token.symbol) }}
+            </nuxt-link>
+          </p>
+        </div>
       </AppDefinition>
     </div>
   </AppPanel>
@@ -50,6 +62,7 @@
 <script>
 import Account from '../components/account.vue'
 import AppDefinition from '../components/appDefinition.vue'
+import AppIcon from '../components/appIcon.vue'
 import AppPanel from '../components/appPanel.vue'
 import FormatAeUnit from '../components/formatAeUnit.vue'
 import formatToken from '../plugins/filters/formatToken'
@@ -59,15 +72,29 @@ export default {
   components: { AppDefinition,
     FormatAeUnit,
     Account,
-    AppPanel },
+    AppPanel,
+    AppIcon
+  },
   filters: { formatToken },
   props: {
     account: { type: Object, required: true },
-    tokensBalance: { type: Array, default: () => [] } }
+    tokensBalance: { type: Array, default: () => [] } },
+  data () {
+    return {
+      showZeros: false
+    }
+  },
+  computed: {
+    tokensWithBalance () {
+      return this.tokensBalance.filter(t => t.amount)
+    }
+  }
 }
 </script>
 
 <style lang="scss" scoped>
+@import "~@aeternity/aepp-components-3/src/styles/variables/colors";
+
 .account-details {
   display: flex;
   flex-direction: column;
@@ -87,7 +114,40 @@ export default {
     }
   }
   .account-details-info {
-    border-top: 2px solid #EDF3F7;
+    border-top: 2px solid $color-neutral-positive-2;
+
+    .show-zero {
+      display: inline-flex;
+      align-items: center;
+      margin-top: 0.2rem;
+      .show-btn {
+        border: none;
+        background: none;
+        padding: 0.1rem;
+        display: inline-flex;
+        align-items: center;
+        border-radius: 50%;
+        color: rgba($color-black, 0.4);
+        background: rgba($color-black, 0.1);
+        cursor: pointer;
+        margin-right: .4rem;
+
+        .app-icon {
+          width: 1.2rem;
+          height: 1.2rem;
+        }
+
+        &.active {
+          color: rgba($color-primary, 0.4);
+          background: rgba($color-primary, 0.1);
+        }
+      }
+    }
+
+    .tokens-balances {
+      max-height: 220px;
+      overflow-y: auto;
+    }
 
     .token {
       margin: 0;
@@ -97,7 +157,7 @@ export default {
       width: 40%;
       flex-direction: row;
       border-top: none;
-      border-left: 2px solid #EDF3F7;
+      border-left: 2px solid $color-neutral-positive-2;
     }
     @media (min-width: 1600px) {
       width: 35%;


### PR DESCRIPTION
Fixes #123 

- Show-hide tokens with balance of 0 switch
<img width="458" alt="Screenshot 2021-11-17 at 17 10 50" src="https://user-images.githubusercontent.com/47859124/142226661-9a49c935-2c32-40bc-b717-26bfce3095a4.png">
- Limit the height of the container (you can scroll through it)
<img width="458" alt="Screenshot 2021-11-17 at 17 10 50" src="https://user-images.githubusercontent.com/47859124/142226886-45138330-eb66-4c4f-8b70-263c280e8073.png">
- Style the transactions table to be a little bit more consistent
<img width="1084" alt="Screenshot 2021-11-17 at 19 46 09" src="https://user-images.githubusercontent.com/47859124/142254239-756acf94-287d-4652-b159-5b5acbbb1db2.png">

