### PR TITLE
fix(accountPage): display if the account is not found

### DIFF
--- a/partials/accountDetails.vue
+++ b/partials/accountDetails.vue
@@ -7,7 +7,22 @@
         title="Address"
         icon
       />
-      <AppDefinition title="Account type">
+      <AppDefinition
+        v-if="account.error"
+        title="Account type"
+      >
+        <div class="error">
+          unknown
+          <AppIcon name="info" />
+          <div class="tooltiptext">
+            The account has never been seen in the network.
+          </div>
+        </div>
+      </AppDefinition>
+      <AppDefinition
+        v-if="account.kind"
+        title="Account type"
+      >
         {{ account.kind }}
       </AppDefinition>
       <Account
@@ -93,7 +108,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "~@aeternity/aepp-components-3/src/styles/variables/colors";
+@import '~@aeternity/aepp-components-3/src/styles/variables/colors';
 
 .account-details {
   display: flex;
@@ -111,6 +126,37 @@ export default {
     }
       @media (min-width: 1600px) {
       width: 65%;
+    }
+    .error {
+      color: $color-red;
+      display: flex;
+      align-items: center;
+      position: relative;
+      .app-icon {
+        margin-left: 0.2rem;
+        cursor: pointer;
+      }
+
+      .tooltiptext {
+        visibility: hidden;
+        width: 200px;
+        word-break: unset;
+        background-color: $color-neutral;
+        font-size: 12px;
+        color: #fff;
+        text-align: center;
+        border-radius: 6px;
+        position: absolute;
+        left: 101%;
+        top: -2px;
+        z-index: 1;
+      }
+
+      &:hover {
+        .tooltiptext {
+          visibility: visible;
+        }
+      }
     }
   }
   .account-details-info {

--- a/store/account.js
+++ b/store/account.js
@@ -3,8 +3,17 @@ import { fetchJson } from './utils'
 export const actions = {
   getAccountDetails: async function ({ rootState: { nodeUrl }, commit }, account) {
     try {
-      const acc = await fetchJson(`${nodeUrl.slice(0, -4)}/v3/accounts/${account}`)
-      return acc
+      const acc = await fetch(`${nodeUrl.slice(0, -4)}/v3/accounts/${account}`)
+      if (!acc.ok) {
+        commit('catchError', 'Error', { root: true })
+        const basicError = {
+          id: account,
+          balance: 0,
+          error: 'Account not found'
+        }
+        return basicError
+      }
+      return acc.json()
     } catch (e) {
       commit('catchError', 'Error', { root: true })
       const basicError = {

--- a/store/tokens.js
+++ b/store/tokens.js
@@ -89,6 +89,9 @@ export const actions = {
   },
   getAccountBalance: async function ({ state: { tokens } }, { address }) {
     const balance = await fetchMiddleware(`aex9/balances/account/${address}`)
+    if (balance.hasOwnProperty('error')) {
+      return []
+    }
     return balance.map((b) => {
       const tokenInfo = tokens.find((t) => t.contractId === b.contractId)
       return {

--- a/store/transactions.js
+++ b/store/transactions.js
@@ -61,6 +61,7 @@ export const actions = {
     } catch (e) {
       console.log(e)
       commit('catchError', 'Error', { root: true })
+      return { data: null, next: false }
     }
   }
 }


### PR DESCRIPTION
Fixes #125 

If the account is non-existent it'll show like this:

<img width="600" src="https://user-images.githubusercontent.com/47859124/142439463-92c02d4a-3858-49c6-9cec-d80238ad2f68.png">

Even if there's no such account there is info for the token transaction that still can be seen.
