### PR TITLE
feat: show transaction status

### DIFF
--- a/components/appLoading.vue
+++ b/components/appLoading.vue
@@ -1,0 +1,122 @@
+<template>
+  <div
+    class="lds-ellipsis tooltip"
+    :style="{
+      'width': `${size * 6}px`,
+      'height': `${size * 6}px`,
+      'margin-top': `-${size * 1.75}px`,
+      'margin-bottom': `-${size * 2.75}px`
+    }"
+  >
+    <span
+      v-if="tooltipText"
+      class="tooltiptext"
+      :style="{
+        'width': `${tooltipText.length * 12}px`
+      }"
+    >
+      {{ tooltipText }}
+    </span>
+
+    <div
+      v-for="i in 4"
+      :key="i"
+      :style="{
+        'width': `${size}px`,
+        'height': `${size}px`,
+        'top': `${(size * 6) / 3 + (size / 2)}px`,
+      }"
+    />
+  </div>
+</template>
+<script>
+export default {
+  name: 'AppLoading',
+  props: {
+    size: {
+      type: Number,
+      required: false,
+      default: 10
+    },
+    tooltipText: {
+      type: String,
+      required: false,
+      default: null
+    }
+  }
+}
+</script>
+<style lang="scss" scoped>
+@import '~@aeternity/aepp-components-3/src/styles/variables/colors';
+@import '~@aeternity/aepp-components-3/src/styles/placeholders/typography';
+.lds-ellipsis {
+  display: inline-block;
+  position: relative;
+}
+.lds-ellipsis div {
+  position: absolute;
+  border-radius: 50%;
+  background: #76818C;
+  animation-timing-function: cubic-bezier(0, 1, 1, 0);
+}
+.lds-ellipsis div:nth-child(1) {
+  left: 8px;
+  animation: lds-ellipsis1 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(2) {
+  left: 8px;
+  animation: lds-ellipsis2 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(3) {
+  left: 32px;
+  animation: lds-ellipsis2 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(4) {
+  left: 56px;
+  animation: lds-ellipsis3 0.6s infinite;
+}
+@keyframes lds-ellipsis1 {
+  0% {
+    transform: scale(0);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+@keyframes lds-ellipsis3 {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0);
+  }
+}
+@keyframes lds-ellipsis2 {
+  0% {
+    transform: translate(0, 0);
+  }
+  100% {
+    transform: translate(24px, 0);
+  }
+}
+
+/* Tooltip text */
+.tooltip .tooltiptext {
+  visibility: hidden;
+  background-color: #76818C;;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  /* Position the tooltip text - see examples below! */
+  position: absolute;
+  top: -10px;
+  z-index: 1;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+</style>

--- a/components/confirmations.vue
+++ b/components/confirmations.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="confirmations">
     <span class="confirmations-num">
-      {{ maxHeight - height }}
+      {{ (maxHeight - height) > 0 ? maxHeight - height : 0 }}
     </span>
     <span class="confirmations-name">
       <span>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -41,8 +41,8 @@ module.exports = {
     }
   ],
   env: {
-    mainnetURL: process.env.NUXT_APP_NODE_URL || 'https://mainnet.aeternity.io/v3',
-    middlewareURL: process.env.NUXT_APP_NODE_URL || 'https://mainnet.aeternity.io/mdw',
+    nodeURL: process.env.NUXT_APP_NODE_URL || 'https://mainnet.aeternity.io/v3',
+    middlewareURL: process.env.NUXT_APP_MDW_URL || 'https://mainnet.aeternity.io/mdw',
     middlewareWS: process.env.NUXT_APP_NODE_WS || 'wss://mainnet.aeternity.io/mdw/websocket',
     networkName: process.env.NUXT_APP_NETWORK_NAME || 'MAIN NET',
     enableFaucet: process.env.NUXT_APP_ENABLE_FAUCET || false,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -41,6 +41,7 @@ module.exports = {
     }
   ],
   env: {
+    mainnetURL: process.env.NUXT_APP_NODE_URL || 'https://mainnet.aeternity.io/v3',
     middlewareURL: process.env.NUXT_APP_NODE_URL || 'https://mainnet.aeternity.io/mdw',
     middlewareWS: process.env.NUXT_APP_NODE_WS || 'wss://mainnet.aeternity.io/mdw/websocket',
     networkName: process.env.NUXT_APP_NETWORK_NAME || 'MAIN NET',
@@ -53,7 +54,8 @@ module.exports = {
   */
   plugins: [
     { src: '~/plugins/directives/copyToClipboard.js' },
-    { src: '~/plugins/directives/removeSpacesOnCopy.js' }
+    { src: '~/plugins/directives/removeSpacesOnCopy.js' },
+    { src: '~/plugins/ws.js' }
   ],
   /*
     ** Router config

--- a/pages/transactions/_transaction/index.vue
+++ b/pages/transactions/_transaction/index.vue
@@ -208,23 +208,29 @@ export default {
   font-size: 16px;
   max-height: 20px;
   .chip-status {
+    display: flex;
+    align-items: center;
     height: 35px;
     border-top-left-radius: 10px;
     border-bottom-left-radius: 10px;
-    padding: 9px 14px;
+    padding: 0 14px;
     color: white;
+    border: 2px solid #15803d;
   }
   .chip-text {
+    display: flex;
+    align-items: center;
     height: 35px;
     border-top-right-radius: 10px;
     border-bottom-right-radius: 10px;
-    padding: 8px 15px;
+    padding: 0 14px;
     border: 2px solid #15803d;
   }
 
   &.unknown {
     .chip-status {
       background-color: #4b5563;
+      border-color:#4b5563;
     }
     .chip-text {
       color: #4b5563;
@@ -235,6 +241,7 @@ export default {
   &.pending {
     .chip-status {
       background-color: #ea580c;
+      border-color:#ea580c;
     }
     .chip-text {
       color: #ea580c;
@@ -245,6 +252,7 @@ export default {
   &.mined {
     .chip-status {
       background-color: #0d9488;
+      border-color:#0d9488;
     }
     .chip-text {
       color: #0d9488;
@@ -255,6 +263,7 @@ export default {
   &.synced {
     .chip-status {
       background-color: #15803d;
+      border-color:#15803d;
     }
     .chip-text {
       color: #15803d;

--- a/pages/transactions/_transaction/index.vue
+++ b/pages/transactions/_transaction/index.vue
@@ -45,7 +45,7 @@ import GenerationDetails from '../../../partials/generationDetails'
 import TransactionDetails from '../../../partials/transactionDetails'
 import FunctionCalls from '../../../partials/functionCalls'
 import PageHeader from '../../../components/PageHeader'
-import { transformMetaTx, fixContractCreateTx, fetchMainnet } from '../../../store/utils'
+import { transformMetaTx, fixContractCreateTx, fetchNode } from '../../../store/utils'
 
 export default {
   name: 'AppTransaction',

--- a/pages/transactions/_transaction/index.vue
+++ b/pages/transactions/_transaction/index.vue
@@ -66,14 +66,14 @@ export default {
       )
     }
     if (!txDetails) {
-      txDetails = await fetchMainnet(`transactions/${transaction}`)
+      txDetails = await fetchNode(`transactions/${transaction}`)
 
       if (txDetails) {
         status = txDetails.block_height < 0 ? 'pending' : 'mined'
       } else {
         status = 'unknown'
       }
-      return { transaction: txDetails ?? {}, status, loading: false }
+      return { transaction: { ...txDetails, _status: status } ?? {}, status, loading: false }
     }
 
     try {
@@ -88,7 +88,7 @@ export default {
 
     }
 
-    return { transaction: txDetails, status, loading: false }
+    return { transaction: { ...txDetails, _status: status }, status, loading: false }
   },
   data () {
     return {

--- a/pages/transactions/_transaction/index.vue
+++ b/pages/transactions/_transaction/index.vue
@@ -203,12 +203,13 @@ export default {
 .chip {
   text-transform: capitalize;
   font-weight: bold;
+  font-size: 16px;
   max-height: 20px;
   .chip-status {
     height: 35px;
     border-top-left-radius: 10px;
     border-bottom-left-radius: 10px;
-    padding: 8px 15px;
+    padding: 9px 14px;
     color: white;
   }
   .chip-text {

--- a/pages/transactions/_transaction/index.vue
+++ b/pages/transactions/_transaction/index.vue
@@ -1,15 +1,26 @@
 <template>
   <div class="app-transaction">
-    <PageHeader
-      title="Transactions"
-      :has-crumbs="true"
-      :page="{ to: '/transactions', name: 'Transactions' }"
-      :subpage="{
-        to: `/transactions/${$route.params.transaction}`,
-        name: 'Transaction Overview',
-      }"
-    />
+    <div class="transaction-header">
+      <PageHeader
+        title="Transactions"
+        :has-crumbs="true"
+        :page="{ to: '/transactions', name: 'Transactions' }"
+        :subpage="{
+          to: `/transactions/${$route.params.transaction}`,
+          name: 'Transaction Overview',
+        }"
+      />
+      <div :class="`chip ${status}`">
+        <div class="chip-status">
+          Status:
+        </div>
+        <div class="chip-text">
+          {{ status }}
+        </div>
+      </div>
+    </div>
     <TransactionDetails
+      v-if="transaction.tx"
       :status="loading"
       :data="transaction"
     />
@@ -17,7 +28,7 @@
       Loading....
     </div>
     <FunctionCalls
-      v-if="functionCalls.length > 0"
+      v-if="functionCalls && functionCalls.length > 0"
       :function-calls="functionCalls"
     />
     <GenerationDetails
@@ -34,7 +45,7 @@ import GenerationDetails from '../../../partials/generationDetails'
 import TransactionDetails from '../../../partials/transactionDetails'
 import FunctionCalls from '../../../partials/functionCalls'
 import PageHeader from '../../../components/PageHeader'
-import { transformMetaTx, fixContractCreateTx } from '../../../store/utils'
+import { transformMetaTx, fixContractCreateTx, fetchMainnet } from '../../../store/utils'
 
 export default {
   name: 'AppTransaction',
@@ -48,6 +59,7 @@ export default {
     let txDetails = null
     let generation = null
     let height = null
+    let status = 'synced'
     txDetails = store.state.transactions.transactions?.[transaction]
     if (!txDetails) {
       txDetails = await store.dispatch(
@@ -56,10 +68,14 @@ export default {
       )
     }
     if (!txDetails) {
-      return error({
-        message: `Transaction not found. If you have sent it only a short time ago, please give the network some time to sync and recheck again in a few seconds.`,
-        statusCode: 400
-      })
+      txDetails = await fetchMainnet(`transactions/${transaction}`)
+
+      if (txDetails) {
+        status = txDetails.block_height < 0 ? 'pending' : 'mined'
+      } else {
+        status = 'unknown'
+      }
+      return { transaction: txDetails ?? {}, generation, height, status, loading: false }
     }
 
     try {
@@ -77,7 +93,7 @@ export default {
 
     }
 
-    return { transaction: txDetails, generation, height, loading: false }
+    return { transaction: txDetails, generation, height, status, loading: false }
   },
   data () {
     return {
@@ -85,7 +101,14 @@ export default {
       generation: {},
       height: 0,
       loading: true,
-      functionCalls: []
+      functionCalls: [],
+      /**
+       * unknown (not seen on the node, ever) // red
+       * pending (in mempool but not included in microblock yet) // orange
+       * mined (included in microblock) // light - green
+       * synced (in microblock and indexed by mdw) green
+       */
+      status: 'unknown'
     }
   },
   async fetch () {
@@ -95,31 +118,154 @@ export default {
     )
   },
   async mounted () {
-    this.loading = true
-    if (!this.generation) {
-      this.generation = (
-        await this.$store.dispatch('generations/getGenerationByRange', {
-          start: this.transaction.blockHeight - 1,
-          end: this.transaction.blockHeight + 1
+    if (this.transaction.tx) {
+      this.loadTransactionData()
+    }
+
+    if (this.status !== 'synced') {
+      this.$ws()
+        .listen('Transactions', (payload) => {
+          if (payload.hash === this.$route.params.transaction) {
+            console.info('===========')
+            console.info('Got Transaction ::', payload, this.$moment().format('LL HH:mm:ss'))
+            console.info('===========')
+            this.transaction = {
+              ...payload
+            }
+            this.status = payload.block_height < 0 ? 'pending' : 'mined'
+            this.reloadTranasaction()
+          }
         })
-      ).find((g) => g.height === this.transaction.blockHeight)
+        .listen('KeyBlocks', (payload) => {
+          this.status = 'synced'
+          this.reloadTranasaction()
+        })
     }
-
-    if (!this.height) {
-      this.height = await this.$store.dispatch('height')
-    }
-
-    if (this.transaction.tx.contractId) {
-      this.transaction.tokenInfo = await this.$store.dispatch(
-        'tokens/getTokenTransactionInfo',
-        {
-          contractId: this.transaction.tx.contractId,
-          address: this.transaction.tx.callerId,
-          id: this.transaction.txIndex
-        }
+  },
+  methods: {
+    async reloadTranasaction () {
+      let transaction = await this.$store.dispatch(
+        'transactions/getTransactionById',
+        this.$route.params.transaction
       )
+      if (transaction) {
+        try {
+          if (transaction.tx.type === 'GAMetaTx') {
+            transaction = transformMetaTx(transaction)
+          }
+
+          if (!transaction.tx.function) {
+            transaction = fixContractCreateTx(transaction)
+          }
+        } catch (error) {
+
+        }
+
+        this.transaction = {
+          ...transaction
+        }
+
+        this.loadTransactionData()
+      }
+    },
+    async loadTransactionData () {
+      this.loading = true
+      if (!this.generation) {
+        this.generation = (
+          await this.$store.dispatch('generations/getGenerationByRange', {
+            start: this.transaction.blockHeight - 1,
+            end: this.transaction.blockHeight + 1
+          })
+        ).find((g) => g.height === this.transaction.blockHeight)
+      }
+
+      if (!this.height) {
+        this.height = await this.$store.dispatch('height')
+      }
+
+      if (this.transaction.tx.contractId) {
+        this.transaction.tokenInfo = await this.$store.dispatch(
+          'tokens/getTokenTransactionInfo',
+          {
+            contractId: this.transaction.tx.contractId,
+            address: this.transaction.tx.callerId,
+            id: this.transaction.txIndex
+          }
+        )
+      }
+      this.loading = false
     }
-    this.loading = false
   }
 }
 </script>
+<style scoped lang="scss">
+
+.transaction-header, .chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.transaction-header {
+  width: 100%;
+}
+
+.chip {
+  text-transform: capitalize;
+  font-weight: bold;
+  max-height: 20px;
+  .chip-status {
+    height: 35px;
+    border-top-left-radius: 10px;
+    border-bottom-left-radius: 10px;
+    padding: 8px 15px;
+    color: white;
+  }
+  .chip-text {
+    height: 35px;
+    border-top-right-radius: 10px;
+    border-bottom-right-radius: 10px;
+    padding: 8px 15px;
+    border: 2px solid #15803d;
+  }
+
+  &.unknown {
+    .chip-status {
+      background-color: #4b5563;
+    }
+    .chip-text {
+      color: #4b5563;
+      border-color:#4b5563;
+    }
+  }
+
+  &.pending {
+    .chip-status {
+      background-color: #ea580c;
+    }
+    .chip-text {
+      color: #ea580c;
+      border-color:#ea580c;
+    }
+  }
+
+  &.mined {
+    .chip-status {
+      background-color: #0d9488;
+    }
+    .chip-text {
+      color: #0d9488;
+      border-color:#0d9488;
+    }
+  }
+
+  &.synced {
+    .chip-status {
+      background-color: #15803d;
+    }
+    .chip-text {
+      color: #15803d;
+      border-color:#15803d;
+    }
+  }
+}
+</style>

--- a/partials/txListType/contractCallTx.vue
+++ b/partials/txListType/contractCallTx.vue
@@ -45,7 +45,12 @@
           <AppDefinition
             title="gas used"
           >
-            {{ transaction.tx.gasUsed }}
+            <span v-if="transaction._status == 'mined'">
+              <app-loading tooltip-text="Waiting for mdw sync" />
+            </span>
+            <span v-else>
+              {{ transaction.tx.gasUsed }}
+            </span>
           </AppDefinition>
           <AppDefinition
             v-if="transaction.tx.gasPrice"
@@ -78,10 +83,16 @@
             <FormatAeUnit :value="transaction.tx.fee" />
           </AppDefinition>
           <AppDefinition
-            v-if="transaction.tx.fee"
+            v-if="transaction.tx.fee || transaction._status == 'mined'"
             title="total cost"
           >
-            <FormatAeUnit :value="transaction.tx.gasUsed * transaction.tx.gasPrice + transaction.tx.fee" />
+            <span v-if="transaction._status == 'mined'">
+              <app-loading tooltip-text="Waiting for mdw sync" />
+            </span>
+            <FormatAeUnit
+              v-else
+              :value="transaction.tx.gasUsed * transaction.tx.gasPrice + transaction.tx.fee"
+            />
           </AppDefinition>
           <AppDefinition
             v-if="transaction.tx.nonce"
@@ -147,6 +158,7 @@ import LabelType from '../../components/labelType'
 import timestampToUTC from '../../plugins/filters/timestampToUTC'
 import formatToken from '../../plugins/filters/formatToken'
 import { transformTxType } from '../../store/utils'
+import AppLoading from '../../components/appLoading.vue'
 
 export default {
   name: 'ContractCallTx',
@@ -155,7 +167,8 @@ export default {
     AppDefinition,
     FormatAeUnit,
     AccountGroup,
-    Account
+    Account,
+    AppLoading
   },
   filters: {
     timestampToUTC,

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -1,0 +1,60 @@
+import camelcaseKeysDeep from 'camelcase-keys-deep'
+/**
+ * AE.mdw VueJs websocket client
+ * channel: "Transactions" | "MicroBlocks" | "KeyBlocks"
+ *
+ * $ws()
+ *  .listen(channel, callback (payload) => ...)
+ *  .listen(channel, callback (payload) => ...)
+ */
+export default async ({ app, env }, inject) => {
+  inject('ws', () => {
+    class AeWebsocket {
+      isConnected = false
+      queueChannels = []
+      supportedChannels = ['Transactions', 'MicroBlocks', 'KeyBlocks']
+
+      constructor () {
+        console.info('INIT WS')
+        this.socket = new WebSocket(env.middlewareWS)
+
+        this.socket.onopen = (e) => {
+          console.info('connected', this.queueChannels)
+          this.isConnected = true
+
+          this.queueChannels.forEach((cb) => cb())
+        }
+      }
+
+      listen (channel, cb = (payload) => console.info(channel, '=>', payload)) {
+        if (!this.supportedChannels.includes(channel)) {
+          throw new Error(
+            `${channel} is not supported, try ${this.supportedChannels.join(
+              ', '
+            )}`
+          )
+        }
+        if (this.isConnected) {
+          this.socket.send(`{"op":"Subscribe", "payload": "${channel}"}`)
+        } else {
+          this.queueChannels.push(() => {
+            this.socket.send(`{"op":"Subscribe", "payload": "${channel}"}`)
+          })
+        }
+
+        this.socket.onmessage = (e) => {
+          if (e.data && e.data.includes('payload')) {
+            let data = camelcaseKeysDeep(JSON.parse(e.data))
+            if (data.subscription === channel) {
+              cb(data.payload)
+            }
+          }
+        }
+
+        return this
+      }
+    }
+
+    return new AeWebsocket()
+  })
+}

--- a/store/utils.js
+++ b/store/utils.js
@@ -82,6 +82,9 @@ export const initMiddleware = () => {
 export const fetchMiddleware = async (path) => {
   return camelcaseKeysDeep(await fetchJson(`${process.env.middlewareURL}/${path}`))
 }
+export const fetchMainnet = async (path) => {
+  return camelcaseKeysDeep(await fetchJson(`${process.env.mainnetURL}/${path}`))
+}
 
 // replacement for lodash times function in vanilla ES5
 export const times = (count, func) => {

--- a/store/utils.js
+++ b/store/utils.js
@@ -82,8 +82,8 @@ export const initMiddleware = () => {
 export const fetchMiddleware = async (path) => {
   return camelcaseKeysDeep(await fetchJson(`${process.env.middlewareURL}/${path}`))
 }
-export const fetchMainnet = async (path) => {
-  return camelcaseKeysDeep(await fetchJson(`${process.env.mainnetURL}/${path}`))
+export const fetchNode = async (path) => {
+  return camelcaseKeysDeep(await fetchJson(`${process.env.nodeURL}/${path}`))
 }
 
 // replacement for lodash times function in vanilla ES5


### PR DESCRIPTION
**What**
New VueJs helper for websocket  `$ws().listen('ChannelName', callback (payload()`

- preload transaction from the node
- track transaction status
- auto-reload transaction when it's available in the middleware 
- fix block confirmation number


**Why**
Fixes #100 
Fixes #87, too
Fixes #106, too